### PR TITLE
Feature/#19 profile get

### DIFF
--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -17,7 +17,7 @@ public class ProfileController {
     private final ProfileService profileService;
 
     @GetMapping("/me")
-    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal String userId) {
+    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal(expression = "username") String userId) {
         ProfileResponse response = profileService.getMyProfile(userId);
         return ApiResponse.success("프로필 조회를 성공했습니다.", response);
     }

--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -17,7 +17,7 @@ public class ProfileController {
     private final ProfileService profileService;
 
     @GetMapping("/me")
-    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal Long userId) {
+    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal String userId) {
         ProfileResponse response = profileService.getMyProfile(userId);
         return ApiResponse.success("프로필 조회를 성공했습니다.", response);
     }

--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -1,0 +1,24 @@
+package com.babgo.controller.profile;
+
+import com.babgo.controller.profile.dto.ProfileResponse;
+import com.babgo.domain.profile.ProfileService;
+import com.babgo.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/profile")
+public class ProfileController {
+
+    private final ProfileService profileService;
+
+    @GetMapping("/me")
+    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal Long userId) {
+        ProfileResponse response = profileService.getMyProfile(userId);
+        return ApiResponse.success("프로필 조회를 성공했습니다.", response);
+    }
+}

--- a/src/main/java/com/babgo/controller/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/babgo/controller/profile/dto/ProfileResponse.java
@@ -10,5 +10,5 @@ public class ProfileResponse {
     private final String name;
     private final String nickname;
     private final String phoneNumber;
-    private final Boolean inProfilePublic;
+    private final Boolean isProfilePublic;
 }

--- a/src/main/java/com/babgo/controller/profile/dto/ProfileResponse.java
+++ b/src/main/java/com/babgo/controller/profile/dto/ProfileResponse.java
@@ -1,0 +1,14 @@
+package com.babgo.controller.profile.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileResponse {
+
+    private final String name;
+    private final String nickname;
+    private final String phoneNumber;
+    private final Boolean inProfilePublic;
+}

--- a/src/main/java/com/babgo/domain/profile/ProfileService.java
+++ b/src/main/java/com/babgo/domain/profile/ProfileService.java
@@ -1,0 +1,30 @@
+package com.babgo.domain.profile;
+
+import com.babgo.controller.profile.dto.ProfileResponse;
+import com.babgo.domain.user.User;
+import com.babgo.global.exception.CustomException;
+import com.babgo.global.exception.ErrorCode;
+import com.babgo.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileService {
+
+    private final UserRepository userRepository;
+
+    public ProfileResponse getMyProfile(Long userId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        return ProfileResponse.builder()
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .isProfilePublic(user.getIsProfilePublic())
+                .build();
+    }
+}

--- a/src/main/java/com/babgo/domain/profile/ProfileService.java
+++ b/src/main/java/com/babgo/domain/profile/ProfileService.java
@@ -16,8 +16,8 @@ public class ProfileService {
 
     private final UserRepository userRepository;
 
-    public ProfileResponse getMyProfile(Long userId) {
-        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+    public ProfileResponse getMyProfile(String userId) {
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         return ProfileResponse.builder()

--- a/src/main/java/com/babgo/domain/user/User.java
+++ b/src/main/java/com/babgo/domain/user/User.java
@@ -9,10 +9,11 @@ import lombok.*;
  * p_users 테이블과 매핑
  */
 @Entity
-@Table(name = "p_users")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @AllArgsConstructor
+@Table(name = "p_users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
 	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
 	FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 
+	// User
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/babgo/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/babgo/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -44,7 +44,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         Map<String, Object> errorDetails = new HashMap<>();
         errorDetails.put("status", 401);
         errorDetails.put("error", "Unauthorized");
-        errorDetails.put("message", "인증이 필요합니다");
+        errorDetails.put("message", "인증이 필요합니다.");
         errorDetails.put("path", request.getRequestURI());
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/main/java/com/babgo/repository/user/UserRepository.java
+++ b/src/main/java/com/babgo/repository/user/UserRepository.java
@@ -14,5 +14,5 @@ public interface UserRepository {
 
     boolean existsByEmail(String email);
 
-    Optional<User> findByIdAndDeletedAtIsNull(Long userId);
+    Optional<User> findByUserIdAndDeletedAtIsNull(String userId);
 }

--- a/src/main/java/com/babgo/repository/user/UserRepository.java
+++ b/src/main/java/com/babgo/repository/user/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByIdAndDeletedAtIsNull(Long userId);
 }

--- a/src/main/java/com/babgo/repository/user/impl/UserJpaRepository.java
+++ b/src/main/java/com/babgo/repository/user/impl/UserJpaRepository.java
@@ -10,4 +10,6 @@ interface UserJpaRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    Optional<User> findByIdAndDeletedAtIsNull(Long userId);
 }

--- a/src/main/java/com/babgo/repository/user/impl/UserJpaRepository.java
+++ b/src/main/java/com/babgo/repository/user/impl/UserJpaRepository.java
@@ -11,5 +11,5 @@ interface UserJpaRepository extends JpaRepository<User, String> {
 
     boolean existsByEmail(String email);
 
-    Optional<User> findByIdAndDeletedAtIsNull(Long userId);
+    Optional<User> findByUserIdAndDeletedAtIsNull(String userId);
 }

--- a/src/main/java/com/babgo/repository/user/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/babgo/repository/user/impl/UserRepositoryImpl.java
@@ -32,4 +32,9 @@ public class UserRepositoryImpl implements UserRepository {
     public boolean existsByEmail(String email) {
         return userJpaRepository.existsByEmail(email);
     }
+
+    @Override
+    public Optional<User> findByIdAndDeletedAtIsNull(Long userId) {
+        return userJpaRepository.findByIdAndDeletedAtIsNull(userId);
+    }
 }

--- a/src/main/java/com/babgo/repository/user/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/babgo/repository/user/impl/UserRepositoryImpl.java
@@ -34,7 +34,7 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByIdAndDeletedAtIsNull(Long userId) {
-        return userJpaRepository.findByIdAndDeletedAtIsNull(userId);
+    public Optional<User> findByUserIdAndDeletedAtIsNull(String userId) {
+        return userJpaRepository.findByUserIdAndDeletedAtIsNull(userId);
     }
 }

--- a/src/test/java/com/babgo/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/babgo/controller/profile/ProfileControllerTest.java
@@ -1,0 +1,63 @@
+package com.babgo.controller.profile;
+
+import com.babgo.domain.user.User;
+import com.babgo.domain.user.UserRole;
+import com.babgo.repository.user.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(classes = com.babgo.BabgoApplication.class)
+@AutoConfigureMockMvc
+class ProfileControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("프로필 조회 - 성공 (인증된 사용자)")
+    @WithMockUser(username = "1", roles = {"CUSTOMER"})
+    void getMyProfile_success() throws Exception {
+        // given
+        User user = User.builder()
+                .userId("1")
+                .email("test@example.com")
+                .password("encodedPw")
+                .name("이다인")
+                .nickname("다인")
+                .phoneNumber("010-1234-5678")
+                .isProfilePublic(true)
+                .role(UserRole.CUSTOMER)
+                .build();
+        userRepository.save(user);
+
+        // when & then
+        mockMvc.perform(get("/api/profile/me"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("프로필 조회를 성공했습니다."))
+                .andExpect(jsonPath("$.data.name").value("이다인"))
+                .andExpect(jsonPath("$.data.nickname").value("다인"))
+                .andExpect(jsonPath("$.data.phoneNumber").value("010-1234-5678"))
+                .andExpect(jsonPath("$.data.isProfilePublic").value(true));
+    }
+
+    @Test
+    @DisplayName("프로필 조회 - 비로그인 사용자 (401 Unauthorized)")
+    void getMyProfile_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/profile/me"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+}


### PR DESCRIPTION
## 개요
> 사용자의 프로필을 조회하는 API를 구현하고, 
> 인증 유저 / 비로그인 유저 케이스를 포함한 통합 테스트 작성
<img width="1202" height="187" alt="스크린샷 2025-10-07 23 44 13" src="https://github.com/user-attachments/assets/18f0386b-1999-4510-a046-ff592aebe6b9" />

## 작업 사항
- 프로필 조회 API 구현 (`/api/profile/me`)
- ProfileService에서 사용자 조회 로직 추가
- ProfileResponse DTO 생성
- ProfileControllerTest 작성 (성공/실패 케이스 포함)

## 리뷰 요청 포인트
- 로직 흐름 자연스러운지 확인 부탁드립니다.
- 유효성 검증 누락된 부분 없는지 봐주세요.

## 기타 사항
관련 이슈: #19 
참고 자료: