### PR TITLE
Feature/#25 profile get facade

### DIFF
--- a/src/main/java/com/babgo/application/profile/ProfileFacade.java
+++ b/src/main/java/com/babgo/application/profile/ProfileFacade.java
@@ -1,0 +1,27 @@
+package com.babgo.application.profile;
+
+import com.babgo.controller.profile.dto.ProfileResponse;
+import com.babgo.domain.profile.ProfileService;
+import com.babgo.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProfileFacade {
+
+    private final ProfileService profileService;
+
+    // get profile
+    public ProfileResponse getMyProfile(String userId) {
+        User user = profileService.getMyProfile(userId);
+        return ProfileResponse.builder()
+                .name(user.getName())
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .isProfilePublic(user.getIsProfilePublic())
+                .build();
+    }
+}

--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -1,7 +1,7 @@
 package com.babgo.controller.profile;
 
+import com.babgo.application.profile.ProfileFacade;
 import com.babgo.controller.profile.dto.ProfileResponse;
-import com.babgo.domain.profile.ProfileService;
 import com.babgo.global.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/profile")
 public class ProfileController {
 
-    private final ProfileService profileService;
+    private final ProfileFacade profileFacade;
 
+    // get profile
     @GetMapping("/me")
-    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal(expression = "username") String userId) {
-        ProfileResponse response = profileService.getMyProfile(userId);
-        return ApiResponse.success("프로필 조회를 성공했습니다.", response);
+    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal String userId) {
+        return ApiResponse.success(profileFacade.getMyProfile(userId));
     }
 }

--- a/src/main/java/com/babgo/domain/profile/ProfileService.java
+++ b/src/main/java/com/babgo/domain/profile/ProfileService.java
@@ -1,6 +1,5 @@
 package com.babgo.domain.profile;
 
-import com.babgo.controller.profile.dto.ProfileResponse;
 import com.babgo.domain.user.User;
 import com.babgo.global.exception.CustomException;
 import com.babgo.global.exception.ErrorCode;
@@ -16,15 +15,9 @@ public class ProfileService {
 
     private final UserRepository userRepository;
 
-    public ProfileResponse getMyProfile(String userId) {
-        User user = userRepository.findByUserIdAndDeletedAtIsNull(userId)
+    // get profile
+    public User getMyProfile(String userId) {
+        return userRepository.findByUserIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-
-        return ProfileResponse.builder()
-                .name(user.getName())
-                .nickname(user.getNickname())
-                .phoneNumber(user.getPhoneNumber())
-                .isProfilePublic(user.getIsProfilePublic())
-                .build();
     }
 }


### PR DESCRIPTION
## 개요
> 프로필 조회 로직을 Service에서 Facade 계층으로 이관하고,  
> 도메인 서비스 분리를 통해 계층 간 책임을 명확히 했습니다.

## 작업 사항
- ProfileService → ProfileFacade로 리팩토링
- ProfileDomainService 추가 (활성 사용자 조회 전담)
- ProfileController가 Facade 호출하도록 수정
- 트랜잭션 및 의존성 구조 정리

## 리뷰 요청 포인트
- Facade, DomainService 간 의존 구조가 자연스러운지 확인 부탁드립니다.
- 컨벤션에 맞게 패키지 구조가 정리되었는지 검토해주세요.

## 기타 사항
관련 이슈: #25 