### PR TITLE
bug: getRole시 잘못된 userid 가져오기 버그 차단

### DIFF
--- a/src/main/java/com/babgo/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/babgo/global/security/jwt/JwtTokenProvider.java
@@ -8,16 +8,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Date;
 
  //JWT 토큰 생성 및 검증 클래스
@@ -27,6 +23,7 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private final JwtProperties jwtProperties;
+    private final UserDetailsService userDetailsService;
     private SecretKey secretKey;
 
     @PostConstruct
@@ -89,19 +86,10 @@ public class JwtTokenProvider {
     }
     public Authentication getAuthentication(String token) {
         String userId = getUserId(token);
-        String email = getEmail(token);
-        String role = getRole(token);
 
-        Collection<GrantedAuthority> authorities = Arrays.asList(
-                new SimpleGrantedAuthority(role)
-        );
+        // UserDetailsService를 통해 실제 UserDetailInfo 객체를 로드
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
 
-        UserDetails principal = User.builder()
-                .username(userId)
-                .password("")
-                .authorities(authorities)
-                .build();
-
-        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 }


### PR DESCRIPTION
## 개요

> `JwtTokenProvider`에서 단순 `User` 객체를 생성하던 방식을 개선하여,
> 실제 `UserDetailInfo`를 로드하도록 인증 구조를 리팩토링했습니다.

## 작업 사항

* `JwtTokenProvider.getAuthentication()`에서 `UserDetailService` 주입받아 `UserDetailInfo` 로드하도록 수정
* `UserDetailService.loadUserByUsername()` 내 `NumberFormatException` 예외 처리 추가
* `@AuthenticationPrincipal`로 `UserDetailInfo` 정상 주입되도록 구조 개선
* 관련 유닛테스트 추가 및 인증 로직 주석 보강

## 리뷰 요청 포인트

* `JwtTokenProvider`와 `UserDetailService` 간 의존 구조가 자연스러운지 검토 부탁드립니다.

## 기타 사항

관련 이슈: #28 
