### PR TITLE
Feature/#23 profile delete

### DIFF
--- a/src/main/java/com/babgo/application/profile/ProfileFacade.java
+++ b/src/main/java/com/babgo/application/profile/ProfileFacade.java
@@ -25,4 +25,10 @@ public class ProfileFacade {
         ProfileInfo info = ProfileInfo.from(request);
         return profileService.updateProfile(userId, info);
     }
+
+    // delete profile
+    @Transactional
+    public void deleteProfile(Long userId) {
+        profileService.deleteProfile(userId);
+    }
 }

--- a/src/main/java/com/babgo/application/profile/ProfileFacade.java
+++ b/src/main/java/com/babgo/application/profile/ProfileFacade.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class ProfileFacade {
 
     private final ProfileService profileService;
@@ -20,14 +19,12 @@ public class ProfileFacade {
     }
 
     // update profile
-    @Transactional
     public ProfileResponse updateProfile(Long userId, ProfileUpdateRequest request) {
         ProfileInfo info = ProfileInfo.from(request);
         return profileService.updateProfile(userId, info);
     }
 
     // delete profile
-    @Transactional
     public void deleteProfile(Long userId) {
         profileService.deleteProfile(userId);
     }

--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -32,4 +32,11 @@ public class ProfileController {
         ProfileResponse response = profileFacade.updateProfile(userId, request);
         return ApiResponse.success("프로필 정보가 수정되었습니다.", response);
     }
+
+    // delete profile
+    @DeleteMapping
+    public ApiResponse<Void> deleteProfile(@AuthenticationPrincipal Long userId) {
+        profileFacade.deleteProfile(userId);
+        return ApiResponse.success("계정이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/babgo/domain/profile/ProfileService.java
+++ b/src/main/java/com/babgo/domain/profile/ProfileService.java
@@ -49,4 +49,17 @@ public class ProfileService {
 
         return ProfileResponse.from(user);
     }
+
+    // delete profile
+    @Transactional
+    public void deleteProfile(Long userId) {
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(userId)
+                                  .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getDeletedAt() != null) {
+            throw new CustomException(ErrorCode.ALREADY_DELETE_USER);
+        }
+
+        user.markAsDeleted();
+    }
 }

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -33,6 +33,9 @@ public enum ErrorCode {
 	DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 존재하는 닉네임입니다."),
 	INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "이메일 또는 비밀번호가 잘못되었습니다."),
 
+	// Profile
+	ALREADY_DELETE_USER(HttpStatus.BAD_REQUEST, "이미 삭제된 계정입니다."),
+
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/babgo/controller/profile/ProfileControllerTest.java
+++ b/src/test/java/com/babgo/controller/profile/ProfileControllerTest.java
@@ -9,9 +9,9 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest(classes = com.babgo.BabgoApplication.class)
 @AutoConfigureMockMvc
@@ -60,7 +60,7 @@ class ProfileControllerTest {
         // given
         User user = User.ofCustomer(
                 "update@example.com",
-                "encodedPw",
+                "newPassword123!",
                 "이다인",
                 "다인",
                 "010-1234-5678"
@@ -99,6 +99,36 @@ class ProfileControllerTest {
         mockMvc.perform(patch("/api/profile")
                         .contentType("application/json")
                         .content(requestBody))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+
+
+    // 프로필 삭제
+    @Test
+    @DisplayName("프로필 삭제 - 성공 (인증된 사용자)")
+    void deleteProfile_success() throws Exception {
+        // given
+        User user = User.ofCustomer(
+                "delete@example.com",
+                "password123!",
+                "이다인",
+                "다인",
+                "010-1234-5678"
+        );
+        userRepository.save(user);
+
+        // when & then
+        mockMvc.perform(delete("/v1/profile")
+                        .header("Authorization", "Bearer mock-token"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("프로필 삭제 - 비로그인 사용자 (401 Unauthorized)")
+    void deleteProfile_unauthorized() throws Exception {
+        mockMvc.perform(delete("/v1/profile"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("Unauthorized"))
                 .andExpect(jsonPath("$.message").value("인증이 필요합니다."));

--- a/src/test/java/com/babgo/domain/profile/ProfileServiceTest.java
+++ b/src/test/java/com/babgo/domain/profile/ProfileServiceTest.java
@@ -21,7 +21,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ProfileServiceTest {
@@ -48,6 +49,7 @@ class ProfileServiceTest {
         );
     }
 
+    // 프로필 조회
     @Test
     @DisplayName("프로필 조회 - 성공")
     void getMyProfile_success() {
@@ -74,6 +76,8 @@ class ProfileServiceTest {
                 .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
     }
 
+
+    // 프로필 수정
     @Test
     @DisplayName("프로필 수정 - 성공 (비밀번호 포함)")
     void updateProfile_success() {
@@ -119,5 +123,46 @@ class ProfileServiceTest {
         assertThatThrownBy(() -> profileService.updateProfile(999L, info))
                 .isInstanceOf(CustomException.class)
                 .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+
+    // 프로필 삭제
+    @Test
+    @DisplayName("프로필 삭제 - 성공")
+    void deleteProfile_success() {
+        // given
+        given(userRepository.findByUserIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+
+        // when
+        profileService.deleteProfile(1L);
+
+        // then
+        verify(userRepository, times(1)).findByUserIdAndDeletedAtIsNull(1L);
+        assertThat(user.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("프로필 삭제 - 실패 (존재하지 않는 유저)")
+    void deleteProfile_fail_userNotFound() {
+        // given
+        given(userRepository.findByUserIdAndDeletedAtIsNull(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> profileService.deleteProfile(999L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.USER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("프로필 삭제 - 실패 (이미 삭제된 계정)")
+    void deleteProfile_fail_alreadyDeleted() {
+        // given
+        user.markAsDeleted();
+        given(userRepository.findByUserIdAndDeletedAtIsNull(1L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> profileService.deleteProfile(1L))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ALREADY_DELETE_USER.getMessage());
     }
 }


### PR DESCRIPTION
## 개요
> 프로필에서 계정 삭제(회원 탈퇴) 기능을 추가했습니다.  
> 사용자가 자신의 프로필 화면에서 계정을 비활성화(soft delete)할 수 있습니다.

## 작업 사항
- ProfileService에 soft delete 로직 추가
- ProfileFacade에 프로필 삭제 기능 추가
- ProfileController에 DELETE /v1/profile API 추가
- ProfileServiceTest, ProfileControllerTest에 프로필 삭제 테스트 코드 작성

## 리뷰 요청 포인트
- 삭제 로직에서 예외 처리(`USER_NOT_FOUND`, `ALREADY_DELETED_USER`)가 적절하게 적용되었는지 확인 부탁드립니다.
- Controller → Facade → Service 계층 간 흐름이 자연스러운지 검토 부탁드립니다.

## 기타 사항
관련 이슈: #23 
참고 자료: