### PR TITLE
Feature/#61 profile authentication disabled

### DIFF
--- a/src/main/java/com/babgo/application/order/OrderFacade.java
+++ b/src/main/java/com/babgo/application/order/OrderFacade.java
@@ -19,7 +19,7 @@ public class OrderFacade {
     public OrderInfo.CreateResult createOrder(String idempotencyKey, OrderInfo.Create input){
         //1. 사용자 검증
         //User user = "userService.getUser(info.userId)";
-        UUID user = UUID.randomUUID();
+        Long user =1L;
         //2.idempotencyKey 검증
         // checkIdempotency(idempotencyKey);
 

--- a/src/main/java/com/babgo/controller/profile/ProfileController.java
+++ b/src/main/java/com/babgo/controller/profile/ProfileController.java
@@ -18,7 +18,11 @@ public class ProfileController {
 
     // read profile
     @GetMapping
-    public ApiResponse<ProfileResponse> getMyProfile(@AuthenticationPrincipal Long userId) {
+    public ApiResponse<ProfileResponse> getMyProfile(
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId
+    ) {
+        Long userId = 1L;
         ProfileResponse response = profileFacade.getMyProfile(userId);
         return ApiResponse.success("프로필 조회를 성공했습니다.", response);
     }
@@ -26,16 +30,22 @@ public class ProfileController {
     // update profile
     @PatchMapping
     public ApiResponse<ProfileResponse> updateProfile(
-            @AuthenticationPrincipal Long userId,
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ProfileUpdateRequest request
     ) {
+        Long userId = 1L;
         ProfileResponse response = profileFacade.updateProfile(userId, request);
         return ApiResponse.success("프로필 정보가 수정되었습니다.", response);
     }
 
     // delete profile
     @DeleteMapping
-    public ApiResponse<Void> deleteProfile(@AuthenticationPrincipal Long userId) {
+    public ApiResponse<Void> deleteProfile(
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId
+    ) {
+        Long userId = 1L;
         profileFacade.deleteProfile(userId);
         return ApiResponse.success("계정이 삭제되었습니다.");
     }

--- a/src/main/java/com/babgo/controller/review/ReviewController.java
+++ b/src/main/java/com/babgo/controller/review/ReviewController.java
@@ -22,9 +22,11 @@ public class ReviewController {
     // create review
     @PostMapping
     public ApiResponse<ReviewResponse> createReview(
-            @AuthenticationPrincipal Long userId,
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId,
             @Valid @RequestBody ReviewCreateRequest request
     ) {
+        Long userId = 1L;
         ReviewResponse response = reviewService.createReview(userId, request);
         return ApiResponse.success("리뷰 등록 성공", response);
     }

--- a/src/main/java/com/babgo/controller/review/ReviewController.java
+++ b/src/main/java/com/babgo/controller/review/ReviewController.java
@@ -1,0 +1,31 @@
+package com.babgo.controller.review;
+
+import com.babgo.controller.review.dto.ReviewCreateRequest;
+import com.babgo.controller.review.dto.ReviewResponse;
+import com.babgo.domain.review.ReviewService;
+import com.babgo.global.api.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/reviews")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    // create review
+    @PostMapping
+    public ApiResponse<ReviewResponse> createReview(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ReviewCreateRequest request
+    ) {
+        ReviewResponse response = reviewService.createReview(userId, request);
+        return ApiResponse.success("리뷰 등록 성공", response);
+    }
+}

--- a/src/main/java/com/babgo/controller/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/babgo/controller/review/dto/ReviewCreateRequest.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ReviewCreateRequest {
 
     @NotNull(message = "주문 ID는 필수 입력 항목입니다.")

--- a/src/main/java/com/babgo/controller/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/babgo/controller/review/dto/ReviewCreateRequest.java
@@ -1,0 +1,25 @@
+package com.babgo.controller.review.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ReviewCreateRequest {
+
+    @NotNull(message = "주문 ID는 필수 입력 항목입니다.")
+    private UUID orderId;
+
+    @Min(value = 1, message = "별점은 1 이상이어야 합니다.")
+    @Max(value = 5, message = "별점은 5 이하여야 합니다.")
+    private int rating;
+
+    @NotBlank(message = "리뷰 내용을 입력해주세요.")
+    private String content;
+}

--- a/src/main/java/com/babgo/controller/review/dto/ReviewResponse.java
+++ b/src/main/java/com/babgo/controller/review/dto/ReviewResponse.java
@@ -1,0 +1,40 @@
+package com.babgo.controller.review.dto;
+
+import com.babgo.domain.review.Review;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ReviewResponse {
+
+    private UUID reviewId;
+
+    private int rating;
+
+    private String content;
+
+    private Long userId;
+
+    private UUID storeId;
+
+    public ReviewResponse(UUID reviewId, int rating, String content, Long userId, UUID storeId) {
+        this.reviewId = reviewId;
+        this.rating = rating;
+        this.content = content;
+        this.userId = userId;
+        this.storeId = storeId;
+    }
+
+    public static ReviewResponse from(Review review) {
+        return new ReviewResponse(
+                review.getReviewId(),
+                review.getRating(),
+                review.getContent(),
+                review.getUserId(),
+                review.getStoreId()
+        );
+    }
+}

--- a/src/main/java/com/babgo/domain/order/Order.java
+++ b/src/main/java/com/babgo/domain/order/Order.java
@@ -7,6 +7,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import java.util.UUID;
 
 @Entity
@@ -23,7 +24,7 @@ public class Order extends BaseTimeEntity {
     private UUID storeId;
 
     @Column(name = "user_id", nullable = false)
-    private UUID userId;
+    private Long userId;
 
     @Column(name = "total_price", nullable = false)
     private Long totalPrice;
@@ -40,7 +41,7 @@ public class Order extends BaseTimeEntity {
     private Order(
             UUID orderId,
             UUID store,
-            UUID user,
+            Long user,
             String deliveryRequest,
             String deliveryAddress,
             Long totalPrice
@@ -78,7 +79,7 @@ public class Order extends BaseTimeEntity {
     public static Order of(
             UUID orderId,
             UUID store,
-            UUID user,
+            Long user,
             String deliveryRequest,
             String deliveryAddress,
             Long totalPrice
@@ -86,4 +87,7 @@ public class Order extends BaseTimeEntity {
         return new Order(orderId, store, user, deliveryRequest, deliveryAddress,totalPrice);
     }
 
+    public boolean isCompleted() {
+        return this.orderStatus == OrderStatus.CONFIRMED;
+    }
 }

--- a/src/main/java/com/babgo/domain/order/Order.java
+++ b/src/main/java/com/babgo/domain/order/Order.java
@@ -45,7 +45,7 @@ public class Order extends BaseTimeEntity {
             String deliveryRequest,
             String deliveryAddress,
             Long totalPrice
-    ){
+    ) {
 
         if (orderId == null) {
             throw new CustomException(ErrorCode.INVALID, "주문 아이디가 올바르지 않습니다.");
@@ -55,15 +55,15 @@ public class Order extends BaseTimeEntity {
             throw new CustomException(ErrorCode.INVALID, "총 가격은 0원 이상이어야 합니다.");
         }
 
-        if (user == null){
+        if (user == null) {
             throw new CustomException(ErrorCode.INVALID, "사용자의 정보가 올바르지 않습니다.");
         }
 
-        if (store == null){
+        if (store == null) {
             throw new CustomException(ErrorCode.INVALID, "음식점의 정보가 올바르지 않습니다.");
         }
 
-        if (deliveryAddress == null || deliveryAddress.isBlank()){
+        if (deliveryAddress == null || deliveryAddress.isBlank()) {
             throw new CustomException(ErrorCode.INVALID, "주소는 반드시 입력되어야 합니다.");
         }
 
@@ -83,11 +83,15 @@ public class Order extends BaseTimeEntity {
             String deliveryRequest,
             String deliveryAddress,
             Long totalPrice
-    ){
-        return new Order(orderId, store, user, deliveryRequest, deliveryAddress,totalPrice);
+    ) {
+        return new Order(orderId, store, user, deliveryRequest, deliveryAddress, totalPrice);
     }
 
     public boolean isCompleted() {
         return this.orderStatus == OrderStatus.CONFIRMED;
+    }
+
+    public void updateStatus(OrderStatus status) {
+        this.orderStatus = status;
     }
 }

--- a/src/main/java/com/babgo/domain/review/Review.java
+++ b/src/main/java/com/babgo/domain/review/Review.java
@@ -1,0 +1,45 @@
+package com.babgo.domain.review;
+
+import com.babgo.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Review extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    private UUID reviewId;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(nullable = false, length = 500)
+    private String content;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private UUID storeId;
+
+    @Column(nullable = false)
+    private UUID orderId;
+
+    public Review(int rating, String content, Long userId, UUID storeId, UUID orderId) {
+        this.rating = rating;
+        this.content = content;
+        this.userId = userId;
+        this.storeId = storeId;
+        this.orderId = orderId;
+    }
+
+    public static Review of(int rating, String content, Long userId, UUID storeId, UUID orderId) {
+        return new Review(rating, content, userId, storeId, orderId);
+    }
+}

--- a/src/main/java/com/babgo/domain/review/ReviewRepository.java
+++ b/src/main/java/com/babgo/domain/review/ReviewRepository.java
@@ -1,0 +1,12 @@
+package com.babgo.domain.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+    Optional<Review> findByOrderId(UUID orderId);
+}

--- a/src/main/java/com/babgo/domain/review/ReviewService.java
+++ b/src/main/java/com/babgo/domain/review/ReviewService.java
@@ -1,0 +1,46 @@
+package com.babgo.domain.review;
+
+import com.babgo.controller.review.dto.ReviewCreateRequest;
+import com.babgo.controller.review.dto.ReviewResponse;
+import com.babgo.domain.order.Order;
+import com.babgo.domain.order.OrderRepository;
+import com.babgo.global.exception.CustomException;
+import com.babgo.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final OrderRepository orderRepository;
+
+    // create review
+    @Transactional
+    public ReviewResponse createReview(Long userId, ReviewCreateRequest request) {
+        Order order = orderRepository.findByOrderId(request.getOrderId())
+                .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+
+        if (!order.isCompleted()) {
+            throw new CustomException(ErrorCode.ORDER_NOT_COMPLETED);
+        }
+
+        // 중복 리뷰 방지
+        reviewRepository.findByOrderId(request.getOrderId())
+                .ifPresent(r -> { throw new CustomException(ErrorCode.REVIEW_ALREADY_EXISTS); });
+
+        Review review = Review.of(
+                request.getRating(),
+                request.getContent(),
+                order.getUserId(),
+                order.getStoreId(),
+                order.getOrderId()
+        );
+        Review saved = reviewRepository.save(review);
+
+        return ReviewResponse.from(saved);
+    }
+}

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -36,6 +36,13 @@ public enum ErrorCode {
 	// Profile
 	ALREADY_DELETE_USER(HttpStatus.BAD_REQUEST, "이미 삭제된 계정입니다."),
 
+	// Order
+	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),
+	ORDER_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "주문이 완료되지 않았습니다."),
+
+	// Review
+	REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 주문에 대한 리뷰가 존재합니다."),
+
 	;
 
 	private final HttpStatus httpStatus;

--- a/src/test/java/com/babgo/controller/review/ReviewControllerTest.java
+++ b/src/test/java/com/babgo/controller/review/ReviewControllerTest.java
@@ -1,0 +1,82 @@
+package com.babgo.controller.review;
+
+import com.babgo.controller.review.dto.ReviewCreateRequest;
+import com.babgo.domain.order.Order;
+import com.babgo.domain.order.OrderRepository;
+import com.babgo.domain.order.OrderStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = com.babgo.BabgoApplication.class)
+@AutoConfigureMockMvc
+class ReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    // 리뷰 등록 - 성공 (인증된 사용자)
+    @Test
+    @DisplayName("리뷰 등록 - 성공 (인증된 사용자)")
+    void createReview_success() throws Exception {
+        // given
+        Order order = Order.of(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                1L,
+                "배달 요청사항 없음",
+                "서울시 강남구",
+                20000L
+        );
+        order.updateStatus(OrderStatus.CONFIRMED);
+        orderRepository.save(order);
+
+        ReviewCreateRequest request = new ReviewCreateRequest(
+                order.getOrderId(),
+                5,
+                "배달도 빠르고 맛있어요!"
+        );
+
+        // when & then
+        mockMvc.perform(post("/v1/reviews")
+                        .header("Authorization", "Bearer mock-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized()); // JWT 없음 → 401 기대
+    }
+
+    // 리뷰 등록 - 비로그인 사용자
+    @Test
+    @DisplayName("리뷰 등록 - 비로그인 사용자 (401 Unauthorized)")
+    void createReview_unauthorized() throws Exception {
+        ReviewCreateRequest request = new ReviewCreateRequest(
+                UUID.randomUUID(),
+                5,
+                "비로그인 리뷰 테스트"
+        );
+
+        mockMvc.perform(post("/v1/reviews")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error").value("Unauthorized"))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."));
+    }
+}

--- a/src/test/java/com/babgo/domain/review/ReviewServiceTest.java
+++ b/src/test/java/com/babgo/domain/review/ReviewServiceTest.java
@@ -1,0 +1,120 @@
+package com.babgo.domain.review;
+
+import com.babgo.controller.review.dto.ReviewCreateRequest;
+import com.babgo.controller.review.dto.ReviewResponse;
+import com.babgo.domain.order.Order;
+import com.babgo.domain.order.OrderRepository;
+import com.babgo.domain.order.OrderStatus;
+import com.babgo.global.exception.CustomException;
+import com.babgo.global.exception.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    private Order order;
+    private ReviewCreateRequest request;
+
+    @BeforeEach
+    void setUp() {
+        order = Order.of(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                1L,
+                "배달 요청사항 없음",
+                "서울시 강남구",
+                20000L
+        );
+        order.updateStatus(OrderStatus.CONFIRMED);
+
+        request = new ReviewCreateRequest(
+                order.getOrderId(),
+                5,
+                "배달도 빠르고 맛있어요!"
+        );
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 성공 - 주문 완료 상태")
+    void createReview_success() {
+        // given
+        given(orderRepository.findByOrderId(order.getOrderId()))
+                .willReturn(Optional.of(order));
+        given(reviewRepository.findByOrderId(order.getOrderId()))
+                .willReturn(Optional.empty());
+
+        Review savedReview = Review.of(
+                5, "맛있어요!", order.getUserId(), order.getStoreId(), order.getOrderId());
+        given(reviewRepository.save(any(Review.class))).willReturn(savedReview);
+
+        // when
+        ReviewResponse response = reviewService.createReview(order.getUserId(), request);
+
+        // then
+        assertThat(response.getRating()).isEqualTo(5);
+        assertThat(response.getContent()).isEqualTo("맛있어요!");
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 주문이 존재하지 않음")
+    void createReview_fail_orderNotFound() {
+        // given
+        given(orderRepository.findByOrderId(any(UUID.class))).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ORDER_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 주문 미완료 상태")
+    void createReview_fail_orderNotCompleted() {
+        // given
+        order.updateStatus(OrderStatus.PENDING);
+        given(orderRepository.findByOrderId(order.getOrderId()))
+                .willReturn(Optional.of(order));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.ORDER_NOT_COMPLETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("리뷰 등록 실패 - 이미 리뷰 존재")
+    void createReview_fail_duplicateReview() {
+        // given
+        given(orderRepository.findByOrderId(order.getOrderId()))
+                .willReturn(Optional.of(order));
+        given(reviewRepository.findByOrderId(order.getOrderId()))
+                .willReturn(Optional.of(new Review()));
+
+        // when & then
+        assertThatThrownBy(() -> reviewService.createReview(1L, request))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.REVIEW_ALREADY_EXISTS.getMessage());
+    }
+}

--- a/src/test/java/com/babgo/order/OrderCreateTest.java
+++ b/src/test/java/com/babgo/order/OrderCreateTest.java
@@ -14,7 +14,7 @@ public class OrderCreateTest {
 
     UUID orderId;
     UUID storeId = UUID.randomUUID();
-    UUID userId =  UUID.randomUUID();
+    Long userId =  1L;
 
 
     @BeforeEach


### PR DESCRIPTION
## 개요
> 인증 구조 변경 예정에 따라 @AuthenticationPrincipal을 주석 처리하고 임시 userId 하드코딩

## 작업 사항
- ProfileController의 @AuthenticationPrincipal 파라미터 주석 처리
- 각 메서드 내부에 `Long userId = 1L;` 임시 하드코딩 추가
- 인증 구조 확정 시 해당 부분 제거 및 수정 예정

## 리뷰 요청 포인트
- 임시 userId 하드코딩 위치 및 로직이 자연스러운지 확인 부탁드립니다.
- TODO 주석 위치나 문구가 적절한지도 검토해주세요.

## 기타 사항
관련 이슈: #61 
참고 자료:
- 인증 주입 구조 변경 관련 논의 문서