### PR TITLE
Feature/#45 review delete

### DIFF
--- a/src/main/java/com/babgo/controller/review/ReviewController.java
+++ b/src/main/java/com/babgo/controller/review/ReviewController.java
@@ -7,6 +7,7 @@ import com.babgo.domain.review.ReviewService;
 import com.babgo.global.api.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,5 +54,17 @@ public class ReviewController {
         Long userId = 2L;
         List<ReviewResponse> reviews = reviewQueryService.getReviewsByUser(userId, sort);
         return ApiResponse.success("사용자 리뷰 조회 성공", reviews);
+    }
+
+    // delete review
+    @DeleteMapping("/{reviewId}")
+    public ResponseEntity<ApiResponse<Void>> deleteReview(
+            @PathVariable UUID reviewId
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId
+    ) {
+        Long userId = 2L;
+        reviewService.deleteReview(userId, reviewId);
+        return ResponseEntity.ok(ApiResponse.success("리뷰가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/babgo/domain/review/Review.java
+++ b/src/main/java/com/babgo/domain/review/Review.java
@@ -72,4 +72,11 @@ public class Review extends BaseTimeEntity {
     public static Review of(int rating, String content, Long userId, UUID storeId, UUID orderId) {
         return new Review(rating, content, userId, storeId, orderId);
     }
+
+    @Enumerated(EnumType.STRING)
+    private ReviewStatus reviewStatus;
+
+    public void updateStatus(ReviewStatus reviewStatus) {
+        this.reviewStatus = reviewStatus;
+    }
 }

--- a/src/main/java/com/babgo/domain/review/ReviewRepository.java
+++ b/src/main/java/com/babgo/domain/review/ReviewRepository.java
@@ -18,4 +18,6 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
     Optional<Review> findByOrderId(UUID orderId);
 
     boolean existsByStore_StoreId(UUID storeId);
+
+    Optional<Review> findByReviewIdAndReviewStatusNot(UUID reviewId, ReviewStatus reviewStatus);
 }

--- a/src/main/java/com/babgo/domain/review/ReviewService.java
+++ b/src/main/java/com/babgo/domain/review/ReviewService.java
@@ -13,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -34,7 +36,9 @@ public class ReviewService {
 
         // 중복 리뷰 방지
         reviewRepository.findByOrderId(request.getOrderId())
-                .ifPresent(r -> { throw new CustomException(ErrorCode.REVIEW_ALREADY_EXISTS); });
+                .ifPresent(r -> {
+                    throw new CustomException(ErrorCode.REVIEW_ALREADY_EXISTS);
+                });
 
         Review review = Review.of(
                 request.getRating(),
@@ -55,5 +59,22 @@ public class ReviewService {
         }
 
         return ReviewResponse.from(saved);
+    }
+
+    @Transactional
+    public void deleteReview(Long userId, UUID reviewId) {
+        Review review = reviewRepository.findByReviewIdAndReviewStatusNot(reviewId, ReviewStatus.DELETED)
+                .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+        if (!review.getUser().getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN_REVIEW_DELETE);
+        }
+
+        if (review.getReviewStatus() == ReviewStatus.DELETED) {
+            throw new CustomException(ErrorCode.ALREADY_DELETED_REVIEW);
+        }
+
+        review.updateStatus(ReviewStatus.DELETED);
+        reviewRepository.save(review);
     }
 }

--- a/src/main/java/com/babgo/domain/review/ReviewStatus.java
+++ b/src/main/java/com/babgo/domain/review/ReviewStatus.java
@@ -1,0 +1,6 @@
+package com.babgo.domain.review;
+
+public enum ReviewStatus {
+    ACTIVE,     // 정상적으로 존재하는 리뷰
+    DELETED     // 삭제된 리뷰
+}

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -65,6 +65,8 @@ public enum ErrorCode {
 	// Review
 	REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 해당 주문에 대한 리뷰가 존재합니다."),
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+	FORBIDDEN_REVIEW_DELETE(HttpStatus.FORBIDDEN, "본인의 리뷰만 삭제할 수 있습니다."),
+	ALREADY_DELETED_REVIEW(HttpStatus.CONFLICT, "이미 삭제된 리뷰입니다."),
 
 	// Payment
 	PAYMENT_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "PG 응답이 시간 초과되었습니다."),


### PR DESCRIPTION
## 개요
> 리뷰 삭제 기능 구현

## 작업 사항
- ReviewStatus Enum 추가 (ACTIVE, DELETED)
- Review 엔티티에 reviewStatus 필드 및 updateStatus() 메서드 추가
- ReviewRepository에 findByReviewIdAndReviewStatusNot() 메서드 추가
- ReviewService에 deleteReview() 로직 구현 (본인 검증 + Soft Delete)
- ErrorCode에 리뷰 삭제 관련 예외 코드 추가 (403, 404, 409)
- ReviewController에 삭제 API 추가 (DELETE /api/v1/reviews/{reviewId})

## 리뷰 요청 포인트
- 리뷰 삭제 시 본인 검증 및 예외 처리 로직이 자연스러운지 확인 부탁드립니다.
- Soft Delete 적용 방식(`ReviewStatus.DELETED`) 적절한지 봐주세요.

## 기타 사항
관련 이슈: #45 
참고 자료: Swagger 명세서 및 기존 리뷰 등록/수정 로직