### PR TITLE
Feature/#86 like delete

### DIFF
--- a/src/main/java/com/babgo/controller/like/LikeController.java
+++ b/src/main/java/com/babgo/controller/like/LikeController.java
@@ -5,10 +5,8 @@ import com.babgo.domain.like.Like;
 import com.babgo.domain.like.LikeService;
 import com.babgo.global.api.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
@@ -29,5 +27,18 @@ public class LikeController {
         Long userId = 1L;
         Like like = likeService.registerLike(userId, storeId);
         return ApiResponse.success("좋아요가 등록되었습니다.", LikeResponse.from(like));
+    }
+
+    // unlike store
+    @DeleteMapping("/{storeId}")
+    public ApiResponse<String> unlikeStore(
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId,
+            @PathVariable UUID storeId
+    ) {
+
+        Long userId = 1L;
+        likeService.unlikeStore(userId, storeId);
+        return ApiResponse.success("좋아요가 해제되었습니다.");
     }
 }

--- a/src/main/java/com/babgo/domain/like/LikeRepository.java
+++ b/src/main/java/com/babgo/domain/like/LikeRepository.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    Optional<Like> findByUserUserIdAndStoreStoreId(Like userID, UUID storeId);
+    Optional<Like> findByUserUserIdAndStoreStoreId(Long userID, UUID storeId);
     boolean existsByUserUserIdAndStoreStoreId(Long userID, UUID storeId);
 }

--- a/src/main/java/com/babgo/domain/like/LikeService.java
+++ b/src/main/java/com/babgo/domain/like/LikeService.java
@@ -8,6 +8,7 @@ import com.babgo.global.exception.ErrorCode;
 import com.babgo.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -33,5 +34,17 @@ public class LikeService {
 
         Like like = Like.of(user, store);
         return likeRepository.save(like);
+    }
+
+    // unlike store
+    @Transactional
+    public void unlikeStore(Long userId, UUID storeId) {
+        Like like = likeRepository.findByUserUserIdAndStoreStoreId(userId, storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.LIKE_NOT_FOUND));
+
+        likeRepository.delete(like);
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
     }
 }

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 
 	//Like
 	LIKE_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 가게입니다."),
+	LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미 좋아요가 해제된 가게입니다."),
 
     // Menu
     MENU_UNAVAILABLE(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
> 좋아요 해제 기능 구

## 작업 사항
- LikeRepository에 findByUserUserIdAndStoreStoreId() 메서드 추가
- LikeService.unlikeStore() 로직 구현
- LIKE_NOT_FOUND 예외 처리 추가 및 에러 메시지 수정
- DELETE /v1/likes/{storeId} 컨트롤러 엔드포인트 구현
- 트랜잭션(@Transactional) 적용

## 리뷰 요청 포인트
- unlikeStore() 로직의 흐름과 예외 처리 적절한지 확인 부탁드립니다.
- 컨트롤러 응답 형식(ApiResponse.success)과 상태 코드 일관성 검토 부탁드립니다.

## 기타 사항
관련 이슈: #86 
브랜치명: `feature/#67-unlike-store`  
참고 자료: 좋아요 등록 (#85 )