### PR TITLE
Feature/#87 favorite create

### DIFF
--- a/src/main/java/com/babgo/controller/favorite/FavoriteController.java
+++ b/src/main/java/com/babgo/controller/favorite/FavoriteController.java
@@ -1,0 +1,35 @@
+package com.babgo.controller.favorite;
+
+import com.babgo.controller.favorite.dto.FavoriteRequest;
+import com.babgo.controller.favorite.dto.FavoriteResponse;
+import com.babgo.domain.favorite.FavoriteService;
+import com.babgo.global.api.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    // add favorite
+    @PostMapping
+    public ResponseEntity<ApiResponse<FavoriteResponse>> addFavorite(
+            // TODO: 인증 추가 예정
+            // @AuthenticationPrincipal Long userId,
+            @RequestBody FavoriteRequest request) {
+
+        Long userId = 1L;
+        FavoriteResponse response = favoriteService.addFavorite(userId, request);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("즐겨찾기가 등록되었습니다.", response));
+    }
+}

--- a/src/main/java/com/babgo/controller/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/com/babgo/controller/favorite/dto/FavoriteRequest.java
@@ -1,0 +1,23 @@
+package com.babgo.controller.favorite.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class FavoriteRequest {
+
+    @NotNull(message = "메뉴 ID는 필수값입니다.")
+    private UUID menuId;
+
+    @NotBlank(message = "옵션 정보는 필수값입니다.")
+    private String option;
+
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
+    private int quantity;
+}

--- a/src/main/java/com/babgo/controller/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/com/babgo/controller/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,50 @@
+package com.babgo.controller.favorite.dto;
+
+import com.babgo.domain.favorite.Favorite;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class FavoriteResponse {
+
+    private UUID favoriteId;
+
+    private UUID menuId;
+
+    private String menuName;
+
+    private String storeName;
+
+    private String option;
+
+    private int quantity;
+
+    private LocalDateTime createdAt;
+
+    public FavoriteResponse(UUID favoriteId, UUID menuId, String menuName,
+                            String storeName, String option, int quantity, LocalDateTime createdAt) {
+        this.favoriteId = favoriteId;
+        this.menuId = menuId;
+        this.menuName = menuName;
+        this.storeName = storeName;
+        this.option = option;
+        this.quantity = quantity;
+        this.createdAt = createdAt;
+    }
+
+    public static FavoriteResponse from(Favorite favorite) {
+        return new FavoriteResponse(
+                favorite.getFavoriteId(),
+                favorite.getMenu().getMenuId(),
+                favorite.getMenu().getName(),
+                favorite.getMenu().getStore().getStoreName(),
+                favorite.getOption(),
+                favorite.getQuantity(),
+                favorite.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/babgo/controller/like/LikeController.java
+++ b/src/main/java/com/babgo/controller/like/LikeController.java
@@ -18,7 +18,7 @@ public class LikeController {
     private final LikeService likeService;
 
     // register like
-    @PostMapping("/{storedId}")
+    @PostMapping("/{storeId}")
     public ApiResponse<LikeResponse> registerLike(
             // TODO: 인증 추가 예정
             // @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/babgo/domain/favorite/Favorite.java
+++ b/src/main/java/com/babgo/domain/favorite/Favorite.java
@@ -1,0 +1,46 @@
+package com.babgo.domain.favorite;
+
+import com.babgo.domain.menu.Menu;
+import com.babgo.domain.user.User;
+import com.babgo.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@Table(name = "p_favorites", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "menu_id"})
+})
+public class Favorite extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "favorite_id")
+    private UUID favoriteId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    private String option;
+    private int quantity;
+
+    private Favorite(User user, Menu menu, String option, int quantity) {
+        this.user = user;
+        this.menu = menu;
+        this.option = option;
+        this.quantity = quantity;
+    }
+
+    public static Favorite create(User user, Menu menu, String option, int quantity) {
+        return new Favorite(user, menu, option, quantity);
+    }
+}

--- a/src/main/java/com/babgo/domain/favorite/FavoriteRepository.java
+++ b/src/main/java/com/babgo/domain/favorite/FavoriteRepository.java
@@ -1,0 +1,11 @@
+package com.babgo.domain.favorite;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, UUID> {
+
+    Optional<Favorite> findByUserUserIdAndMenuMenuId(Long userId, UUID menuId);
+}

--- a/src/main/java/com/babgo/domain/favorite/FavoriteService.java
+++ b/src/main/java/com/babgo/domain/favorite/FavoriteService.java
@@ -1,0 +1,45 @@
+package com.babgo.domain.favorite;
+
+import com.babgo.controller.favorite.dto.FavoriteRequest;
+import com.babgo.controller.favorite.dto.FavoriteResponse;
+import com.babgo.domain.menu.Menu;
+import com.babgo.domain.menu.MenuRepository;
+import com.babgo.domain.menu.MenuStatus;
+import com.babgo.domain.user.User;
+import com.babgo.global.exception.CustomException;
+import com.babgo.global.exception.ErrorCode;
+import com.babgo.repository.user.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
+
+    // add favorite
+    @Transactional
+    public FavoriteResponse addFavorite(Long userId, FavoriteRequest request) {
+        User user = userRepository.findByUserIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Menu menu = menuRepository.findById(request.getMenuId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        if (menu.getMenuStatus() == MenuStatus.SOLD_OUT || menu.getMenuStatus() == MenuStatus.DELETED) {
+            throw new CustomException(ErrorCode.MENU_UNAVAILABLE);
+        }
+
+        favoriteRepository.findByUserUserIdAndMenuMenuId(userId, menu.getMenuId())
+                .ifPresent(f -> { throw new CustomException(ErrorCode.FAVORITE_ALREADY_EXISTS); });
+
+        Favorite favorite = Favorite.create(user, menu, request.getOption(), request.getQuantity());
+        Favorite saved = favoriteRepository.save(favorite);
+
+        return FavoriteResponse.from(saved);
+    }
+}

--- a/src/main/java/com/babgo/domain/like/Like.java
+++ b/src/main/java/com/babgo/domain/like/Like.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 public class Like extends BaseTimeEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
     private UUID likeId;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/babgo/domain/like/LikeRepository.java
+++ b/src/main/java/com/babgo/domain/like/LikeRepository.java
@@ -7,6 +7,6 @@ import java.util.UUID;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
-    Optional<Like> findByUserUserIdAndStoreStoreId(Long userID, UUID storeId);
-    boolean existsByUserUserIdAndStoreStoreId(Long userID, UUID storeId);
+    Optional<Like> findByUserUserIdAndStoreStoreId(Long userId, UUID storeId);
+    boolean existsByUserUserIdAndStoreStoreId(Long userId, UUID storeId);
 }

--- a/src/main/java/com/babgo/domain/like/LikeService.java
+++ b/src/main/java/com/babgo/domain/like/LikeService.java
@@ -21,6 +21,7 @@ public class LikeService {
     private final StoreRepository storeRepository;
 
     // register like
+    @Transactional
     public Like registerLike(Long userId, UUID storeId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/babgo/global/exception/ErrorCode.java
+++ b/src/main/java/com/babgo/global/exception/ErrorCode.java
@@ -54,8 +54,12 @@ public enum ErrorCode {
 	LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "이미 좋아요가 해제된 가게입니다."),
 
     // Menu
-    MENU_UNAVAILABLE(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 메뉴를 찾을 수 없습니다."),
     OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "해당 메뉴의 재고가 부족합니다."),
+
+	// Favorite
+	MENU_UNAVAILABLE(HttpStatus.BAD_REQUEST, "현재 즐겨찾기할 수 없는 메뉴입니다."),
+	FAVORITE_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 즐겨찾기한 메뉴입니다."),
 
 	// Order
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 주문을 찾을 수 없습니다."),


### PR DESCRIPTION
## 개요
> 사용자가 특정 메뉴를 즐겨찾기에 등록할 수 있는 기능을 구현했습니다.

## 작업 사항
- Favorite 엔티티 및 Repository 생성
- FavoriteRequest / FavoriteResponse DTO 추가 (@Valid 검증 포함)
- FavoriteService.addFavorite() 등록 로직 구현
  - 메뉴 존재 및 상태(MenuStatus) 검증
  - 중복 등록 방지 (findByUserUserIdAndMenuMenuId)
  - 예외 처리: MENU_UNAVAILABLE, FAVORITE_ALREADY_EXISTS
- FavoriteController 구현 (POST /v1/favorites)
  - ApiResponse 응답 구조 적용
  - 추후 인증(@AuthenticationPrincipal) 추가 예정
- ErrorCode에 MENU_UNAVAILABLE, FAVORITE_ALREADY_EXISTS 상수 추가
- @Transactional 추가 및 오타 수정 리팩토링

## 리뷰 요청 포인트
- 즐겨찾기 등록 로직에서 예외 처리 흐름이 자연스러운지 확인 부탁드립니다.
- 메뉴 상태 검증 조건(MenuStatus.SOLD_OUT, DELETED) 적절한지 검토 부탁드립니다.
- DTO 검증(@NotNull, @NotBlank, @Min) 누락된 부분 없는지 봐주세요.

## 기타 사항
관련 이슈: #87  
참고 자료: 내부 API 명세서 v1.2 / LikeService 구조 참고